### PR TITLE
Allow later version of main dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
 source 'https://rubygems.org'
 
 group :default do
-  gem 'highline', '1.7.8'
-  gem 'net-ssh', '4.1.0'
-  gem 'text-interpolator', '1.1.9'
-  gem 'json_pure', '2.1.0'
-  gem 'parslet', '1.8.0'
-  gem 'thor', '0.19.4'
+  gem 'highline', '>= 1.7.8'
+  gem 'net-ssh', '>= 4.1.0'
+  gem 'text-interpolator', '>= 1.1.9'
+  gem 'json_pure', '>= 2.1.0'
+  gem 'parslet', '>= 1.8.0'
+  gem 'thor', '>= 0.19.4'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,13 +35,13 @@ DEPENDENCIES
   awesome_print (= 1.8.0)
   gemcutter (= 0.7.1)
   gemspec_deps_gen (= 1.1.2)
-  highline (= 1.7.8)
-  json_pure (= 2.1.0)
-  net-ssh (= 4.1.0)
-  parslet (= 1.8.0)
+  highline (>= 1.7.8)
+  json_pure (>= 2.1.0)
+  net-ssh (>= 4.1.0)
+  parslet (>= 1.8.0)
   rspec (= 3.6.0)
-  text-interpolator (= 1.1.9)
-  thor (= 0.19.4)
+  text-interpolator (>= 1.1.9)
+  thor (>= 0.19.4)
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/script_executor.gemspec
+++ b/script_executor.gemspec
@@ -17,13 +17,13 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   
-  spec.add_runtime_dependency "highline", ["= 1.7.8"]
-  spec.add_runtime_dependency "net-ssh", ["= 4.1.0"]
-  spec.add_runtime_dependency "text-interpolator", ["= 1.1.9"]
-  spec.add_runtime_dependency "json_pure", ["= 2.1.0"]
-  spec.add_runtime_dependency "parslet", ["= 1.8.0"]
-  spec.add_runtime_dependency "thor", ["= 0.19.4"]
-  spec.add_runtime_dependency "rspec", ["= 3.6.0"]
+  spec.add_runtime_dependency "highline", [">= 1.7.8"]
+  spec.add_runtime_dependency "net-ssh", [">= 4.1.0"]
+  spec.add_runtime_dependency "text-interpolator", [">= 1.1.9"]
+  spec.add_runtime_dependency "json_pure", [">= 2.1.0"]
+  spec.add_runtime_dependency "parslet", [">= 1.8.0"]
+  spec.add_runtime_dependency "thor", [">= 0.19.4"]
+  spec.add_development_dependency "rspec", ["= 3.6.0"]
   spec.add_development_dependency "gemspec_deps_gen", ["= 1.1.2"]
   spec.add_development_dependency "gemcutter", ["= 0.7.1"]
   spec.add_development_dependency "awesome_print", ["= 1.8.0"]


### PR DESCRIPTION
 Allow later version of main dependencies to lower risk of conflicts when used as a library.

When using with Thor 1.0.0, I get the following error:
```
Unable to activate script_executor-1.7.8, because thor-1.0.0 conflicts with thor (= 0.19.4) (Gem::ConflictError)
```
